### PR TITLE
Review restarting policy

### DIFF
--- a/lib/travis/cli.rb
+++ b/lib/travis/cli.rb
@@ -13,7 +13,6 @@ module Travis
     namespace 'travis'
 
     desc 'config', 'Sync config between keychain, app and local working directory'
-    method_option :restart, :aliases => '-r', :type => :boolean, :default => true
     method_option :backup,  :aliases => '-b', :type => :boolean, :default => false
 
     def config(remote)

--- a/lib/travis/cli/config.rb
+++ b/lib/travis/cli/config.rb
@@ -17,7 +17,6 @@ module Travis
       def invoke
         store
         push
-        restart if restart?
       end
 
       protected
@@ -49,18 +48,9 @@ module Travis
           run "heroku config:add travis_config=#{config} -r #{remote}", :echo => "heroku config:add travis_config=... -r #{app}"
         end
 
-        def restart
-          say 'Restarting the app ...'
-          run "heroku restart -r #{remote}"
-        end
-
         def backup
           say 'Backing up the old config file ...'
           run "cp #{filename} #{filename}.backup"
-        end
-
-        def restart?
-          !!options['restart']
         end
 
         def backup?

--- a/lib/travis/cli/deploy.rb
+++ b/lib/travis/cli/deploy.rb
@@ -77,6 +77,12 @@ module Travis
         def migrate
           say 'Running migrations'
           run "heroku run rake db:migrate -r #{remote}"
+          restart
+        end
+
+        def restart
+          say 'Restarting the app ...'
+          run "heroku restart -r #{remote}"
         end
     end
   end

--- a/lib/travis/cli/deploy.rb
+++ b/lib/travis/cli/deploy.rb
@@ -67,7 +67,7 @@ module Travis
         end
 
         def configure
-          Config.new(shell, remote, :restart => false).invoke
+          Config.new(shell, remote, {}).invoke
         end
 
         def migrate?

--- a/spec/travis/cli/config_spec.rb
+++ b/spec/travis/cli/config_spec.rb
@@ -29,17 +29,5 @@ describe Travis::Cli::Config do
       command.expects(:run).with { |cmd, options| cmd =~ /heroku config:add travis_config=.* -r staging/m }
       command.invoke
     end
-
-    it 'restarts the app when --restart is given' do
-      command = Travis::Cli::Config.new(shell, 'staging', 'restart' => true)
-      command.expects(:restart)
-      command.invoke
-    end
-
-    it 'does not restart the app when --restart is not given' do
-      command = Travis::Cli::Config.new(shell, 'staging', {})
-      command.expects(:restart).never
-      command.invoke
-    end
   end
 end

--- a/spec/travis/cli/deploy_spec.rb
+++ b/spec/travis/cli/deploy_spec.rb
@@ -88,6 +88,13 @@ describe Travis::Cli::Deploy do
       command.invoke
     end
 
+    it 'restarts the app when the database is migrated' do
+      command = Travis::Cli::Deploy.new(shell, 'production', 'migrate' => true)
+      command.stubs(:system).returns(true)
+      command.expects(:system).with('heroku restart -r production').returns(true)
+      command.invoke
+    end
+
     it 'configures the application if --configure is given' do
       command = Travis::Cli::Deploy.new(shell, 'production', 'configure' => true)
       command.stubs(:system).returns(true)


### PR DESCRIPTION
This has two changes:

1) Don't restart the app after updating the configuration. Heroku automatically does this.
2) Restart the app after running the database migrations because the app needs the updated schema.
