### PR TITLE
Use https url to retrieve public key

### DIFF
--- a/lib/travis/cli/secure_key.rb
+++ b/lib/travis/cli/secure_key.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'net/http'
+require 'net/https'
 require 'multi_json'
 require 'openssl'
 require 'base64'
@@ -23,9 +23,12 @@ module Travis
       end
 
       def fetch_key
-        uri = URI.parse("http://travis-ci.org/#{slug}.json")
+        uri = URI.parse("https://travis-ci.org/#{slug}.json")
 
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        
         request = Net::HTTP::Get.new(uri.request_uri)
 
         response = http.request(request)

--- a/lib/travis/cli/secure_key.rb
+++ b/lib/travis/cli/secure_key.rb
@@ -27,7 +27,6 @@ module Travis
 
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         
         request = Net::HTTP::Get.new(uri.request_uri)
 


### PR DESCRIPTION
Hello,

When trying to encrypt an env I was getting the following error:

```
evdb@custard $ travis encrypt mysociety/popit foo=bar

About to encrypt 'foo=bar' for 'mysociety/popit'

There was an error while fetching public key, please check if you entered correct slug
```

Digging into the code and requesting the non-secure manually leads to a redirection to the secure url. `http://travis-ci.org/mysociety/popit.json` 301s to `https://travis-ci.org/mysociety/popit.json`

This pull request changes the url requested to be the secure one, and it now seems to work:

```
evdb@custard $ ./bin/travis encrypt mysociety/popit foo=bar

About to encrypt 'foo=bar' for 'mysociety/popit'

Please add the following to your .travis.yml file:

  secure: "H/WfWa7eoibxl/lGolJSKYETJGsMPWpgGF+vx0QogQiheNuyZYOxMl8rns5l\nbGPAiFxludAlaPWR+1t/tfWVunHuZMuysGlxdfLxJK+SDBPzD0hJNctT5TtC\naEikldU9U+DvppQESKeSwt1EuN+XMopIjjTQjy9K+eS2A8mGxDs="
```

Lovely lovely service. Thanks!
