### PR TITLE
Fixes fetching public keys over HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 script: rspec
 rvm:
+  - 1.8.7
   - 1.9.2
+  - 1.9.3
   - jruby
 notifications:
   irc: "irc.freenode.org#travis"

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,5 @@
-require 'rake'
 require 'rspec/core/rake_task'
-require 'tasks/standalone_migrations'
 
-desc 'Run specs'
-RSpec::Core::RakeTask.new do |t|
-  t.pattern = './spec/**/*_spec.rb'
-end
+RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec

--- a/lib/travis/cli/secure_key.rb
+++ b/lib/travis/cli/secure_key.rb
@@ -23,9 +23,11 @@ module Travis
       end
 
       def fetch_key
-        uri = URI.parse("http://travis-ci.org/#{slug}.json")
+        uri = URI.parse("https://travis-ci.org/#{slug}.json")
 
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
         request = Net::HTTP::Get.new(uri.request_uri)
 
         response = http.request(request)

--- a/lib/travis_cli/version.rb
+++ b/lib/travis_cli/version.rb
@@ -1,3 +1,0 @@
-module TravisCli
-  VERSION = "0.0.6"
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 ENV['RAILS_ENV'] = ENV['ENV'] = 'test'
 
 RSpec.configure do |c|
-  c.before(:each) { Time.now.utc.tap { | now| Time.stub(:now => now) } }
+  c.before(:each) { Time.stub(:now => Time.now.utc) }
 end
 
 require 'travis/cli'
@@ -29,4 +29,3 @@ module Kernel
     $stdout = STDOUT
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,11 @@
 ENV['RAILS_ENV'] = ENV['ENV'] = 'test'
 
+require 'travis/cli'
+require 'webmock/rspec'
+
 RSpec.configure do |c|
   c.before(:each) { Time.stub(:now => Time.now.utc) }
 end
-
-require 'travis/cli'
 
 module Mock
   class Shell

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,10 @@
 ENV['RAILS_ENV'] = ENV['ENV'] = 'test'
 
 RSpec.configure do |c|
-  c.mock_with :mocha
-  c.before(:each) { Time.now.utc.tap { | now| Time.stubs(:now).returns(now) } }
+  c.before(:each) { Time.now.utc.tap { | now| Time.stub(:now => now) } }
 end
 
 require 'travis/cli'
-require 'mocha'
 
 module Mock
   class Shell

--- a/spec/travis/cli/config_spec.rb
+++ b/spec/travis/cli/config_spec.rb
@@ -5,28 +5,28 @@ describe Travis::Cli::Config do
   let(:config) { "staging:\n  foo: bar" }
 
   before :each do
-    Travis::Cli::Config.any_instance.stubs(:clean?).returns(true)
-    Travis::Cli::Config.any_instance.stubs(:run)
-    Travis::Keychain.any_instance.stubs(:fetch).returns(config)
-    File.stubs(:open)
+    Travis::Cli::Config.any_instance.stub(:clean? => true)
+    Travis::Cli::Config.any_instance.stub(:run)
+    Travis::Keychain.any_instance.stub(:fetch => config)
+    File.stub(:open)
   end
 
   describe 'sync' do
     it 'fetches the config from the keychain' do
       command = Travis::Cli::Config.new(shell, 'staging', {})
-      command.send(:keychain).expects(:fetch).returns(config)
+      command.send(:keychain).should_receive(:fetch).and_return(config)
       command.invoke
     end
 
     it 'writes the config to the local config file' do
       command = Travis::Cli::Config.new(shell, 'staging', {})
-      File.expects(:open).with { |path, mode| path =~ %r(config/travis.yml) }
+      File.should_receive(:open).with { |path, mode| path =~ %r(config/travis.yml) }
       command.invoke
     end
 
     it 'pushes the config to the given heroku remote' do
       command = Travis::Cli::Config.new(shell, 'staging', {})
-      command.expects(:run).with { |cmd, options| cmd =~ /heroku config:add travis_config=.* -r staging/m }
+      command.should_receive(:run).with { |cmd, options| cmd =~ /heroku config:add travis_config=.* -r staging/m }
       command.invoke
     end
   end

--- a/spec/travis/cli/deploy_spec.rb
+++ b/spec/travis/cli/deploy_spec.rb
@@ -5,9 +5,9 @@ describe Travis::Cli::Deploy do
 
   before :each do
     $stdout = StringIO.new
-    Travis::Cli::Deploy.any_instance.stubs(:clean?).returns(true)
-    Travis::Cli::Deploy.any_instance.stubs(:branch).returns('master')
-    File.stubs(:open)
+    Travis::Cli::Deploy.any_instance.stub(:clean? => true)
+    Travis::Cli::Deploy.any_instance.stub(:branch => 'master')
+    File.stub(:open)
   end
 
   after :each do
@@ -19,41 +19,41 @@ describe Travis::Cli::Deploy do
       let(:command) { Travis::Cli::Deploy.new(shell, 'production', {}) }
 
       before :each do
-        command.stubs(:system).returns(true)
+        command.stub(:system => true)
       end
 
       it 'switches to the production branch' do
-        command.expects(:system).with('git checkout production').returns(true)
+        command.should_receive(:system).with('git checkout production').and_return(true)
         command.invoke
       end
 
       it 'resets the production branch to the current branch' do
-        command.expects(:system).with('git reset --hard master').returns(true)
+        command.should_receive(:system).with('git reset --hard master').and_return(true)
         command.invoke
       end
 
       it 'pushes the production branch to origin' do
-        command.expects(:system).with('git push origin production -f').returns(true)
+        command.should_receive(:system).with('git push origin production -f').and_return(true)
         command.invoke
       end
 
       it 'switches back to the previous branch' do
-        command.expects(:system).with('git checkout master').returns(true)
+        command.should_receive(:system).with('git checkout master').and_return(true)
         command.invoke
       end
 
       it 'tags the current commit ' do
-        command.expects(:system).with { |cmd| cmd =~ /git tag -a 'deploy.*' -m 'deploy.*'/ }.returns(true)
+        command.should_receive(:system).with { |cmd| cmd =~ /git tag -a 'deploy.*' -m 'deploy.*'/ }.and_return(true)
         command.invoke
       end
 
       it 'pushes the tag to origin' do
-        command.expects(:system).with('git push --tags').returns(true)
+        command.should_receive(:system).with('git push --tags').and_return(true)
         command.invoke
       end
 
       it 'pushes to the given remote' do
-        command.expects(:system).with('git push production HEAD:master -f').returns(true)
+        command.should_receive(:system).with('git push production HEAD:master -f').and_return(true)
         command.invoke
       end
     end
@@ -62,43 +62,43 @@ describe Travis::Cli::Deploy do
       let(:command) { Travis::Cli::Deploy.new(shell, 'staging', {}) }
 
       before :each do
-        command.stubs(:system).returns(true)
+        command.stub(:system => true)
       end
 
       it 'does not switch to the production branch' do
-        command.expects(:system).with('git checkout production').never
+        command.should_not_receive(:system).with('git checkout production')
         command.invoke
       end
 
       it 'does not tag the current commit if the given remote is "staging"' do
-        command.expects(:system).with { |cmd| cmd =~ /git tag -a 'deploy .*' -m 'deploy .*'/ }.never
+        command.should_not_receive(:system).with { |cmd| cmd =~ /git tag -a 'deploy .*' -m 'deploy .*'/ }
         command.invoke
       end
 
       it 'pushes to the given remote' do
-        command.expects(:system).with('git push staging HEAD:master -f').returns(true)
+        command.should_receive(:system).with('git push staging HEAD:master -f').and_return(true)
         command.invoke
       end
     end
 
     it 'migrates the database if --migrate is given' do
       command = Travis::Cli::Deploy.new(shell, 'production', 'migrate' => true)
-      command.stubs(:system).returns(true)
-      command.expects(:system).with('heroku run rake db:migrate -r production').returns(true)
+      command.stub(:system => true)
+      command.should_receive(:system).with('heroku run rake db:migrate -r production').and_return(true)
       command.invoke
     end
 
     it 'restarts the app when the database is migrated' do
       command = Travis::Cli::Deploy.new(shell, 'production', 'migrate' => true)
-      command.stubs(:system).returns(true)
-      command.expects(:system).with('heroku restart -r production').returns(true)
+      command.stub(:system => true)
+      command.should_receive(:system).with('heroku restart -r production').and_return(true)
       command.invoke
     end
 
     it 'configures the application if --configure is given' do
       command = Travis::Cli::Deploy.new(shell, 'production', 'configure' => true)
-      command.stubs(:system).returns(true)
-      command.expects(:configure)
+      command.stub(:system => true)
+      command.should_receive(:configure)
       command.invoke
     end
   end
@@ -109,8 +109,8 @@ describe Travis::Cli::Deploy do
 
     it 'outputs an error message' do
       command = Travis::Cli::Deploy.new(shell, 'production', {})
-      command.stubs(:clean?).returns(false)
-      command.expects(:error).with('There are unstaged changes.')
+      command.stub(:clean? => false)
+      command.should_receive(:error).with('There are unstaged changes.')
       command.invoke
     end
   end

--- a/spec/travis/cli/secure_key_spec.rb
+++ b/spec/travis/cli/secure_key_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Travis::Cli::SecureKey do
+  describe 'key' do
+    before do
+      # Travis API requests redirect to HTTPS
+      stub_request(:any, %r(^http://travis-ci\.org/)).to_return do |request|
+        {
+          :body => '',
+          :status => [301, 'Moved Permanently'],
+          :headers => {
+            'Location' => request.uri.to_s.sub(/^http/, 'https')
+          }
+        }
+      end
+    end
+
+    it 'fetches the public key for a valid slug' do
+      slug = 'travis-ci/travis-cli'
+      public_key = <<-KEY
+-----BEGIN RSA PUBLIC KEY-----
+MIGJAoGBAON8DcLBjBwkspYPtHvdjoOYwjsUJOh5Otr+TEOlfvUgDjc/kGRjP6ku
+THug6JpLU0GlRqOr4u9sFuJCKlDjCJV+2vWzP4e+3zrP9hZGdQUcbG2fhSOBn2Wv
+9wFMn+WFgJ3fEsvIb5yzNsRnH3mMe1MZkTPBZIrt+6M1lM1yOZQpAgMBAAE=
+-----END RSA PUBLIC KEY-----
+KEY
+
+      stub_request(:get, "https://travis-ci.org/#{slug}.json").to_return(
+        {
+          :body => %({"id":4756,"slug":#{MultiJson.dump(slug)},"description":"Travis CLI tool","public_key":#{MultiJson.dump(public_key)},"last_build_id":2619122,"last_build_number":"19","last_build_status":0,"last_build_result":0,"last_build_duration":64,"last_build_language":null,"last_build_started_at":"2012-10-01T04:01:10Z","last_build_finished_at":"2012-10-01T04:01:51Z"}),
+          :status => [200, 'OK']
+        }
+      )
+
+      secure_key = Travis::Cli::SecureKey.new(slug)
+
+      expect{
+        secure_key.key
+      }.to_not raise_error(Travis::Cli::SecureKey::FetchKeyError)
+
+      secure_key.key.to_pem.should == OpenSSL::PKey::RSA.new(public_key).to_pem
+    end
+  end
+end

--- a/spec/travis/keychain_spec.rb
+++ b/spec/travis/keychain_spec.rb
@@ -5,10 +5,10 @@ describe Travis::Keychain do
   let(:keychain) { Travis::Keychain.new('hub', shell) }
 
   before :each do
-    keychain.stubs(:system).returns(true)
-    keychain.stubs(:`)
-    keychain.stubs(:clean?).returns(true)
-    File.stubs(:read)
+    keychain.stub(:system => true)
+    keychain.stub(:`)
+    keychain.stub(:clean? => true)
+    File.stub(:read)
   end
 
   def fetch
@@ -19,23 +19,23 @@ describe Travis::Keychain do
 
   describe 'fetch' do
     it 'changes to the keychain directory' do
-      Dir.expects(:chdir).with { |path| path =~ %r(/travis-keychain$) }
+      Dir.should_receive(:chdir).with { |path| path =~ %r(/travis-keychain$) }
       fetch
     end
 
     it 'errors if the working directory is dirty' do
-      keychain.stubs(:clean?).returns(false)
-      keychain.expects(:error).with('There are unstaged changes in your travis-keychain working directory.')
+      keychain.stub(:clean? => false)
+      keychain.should_receive(:error).with('There are unstaged changes in your travis-keychain working directory.')
       fetch
     end
 
     it 'pulls changes from origin' do
-      keychain.expects(:run).with('git pull')
+      keychain.should_receive(:run).with('git pull')
       fetch
     end
 
     it 'reads the configuration' do
-      File.expects(:read).with { |path| path =~ %r(config/travis.hub.yml$) }
+      File.should_receive(:read).with { |path| path =~ %r(config/travis.hub.yml$) }
       fetch
     end
   end

--- a/travis-cli.gemspec
+++ b/travis-cli.gemspec
@@ -1,24 +1,22 @@
 # encoding: utf-8
 
-$:.unshift File.expand_path('../lib', __FILE__)
-require 'travis_cli/version'
+Gem::Specification.new do |gem|
+  gem.name    = 'travis'
+  gem.version = '0.0.6'
 
-Gem::Specification.new do |s|
-  s.name         = "travis"
-  s.version      = TravisCli::VERSION
-  s.authors      = ["Travis CI"]
-  s.email        = "contact@travis-ci.org"
-  s.homepage     = "https://github.com/travis-ci/travis-cli"
-  s.summary      = "[summary]"
-  s.description  = "[description]"
+  gem.authors     = ['Travis CI']
+  gem.email       = ['contact@travis-ci.org']
+  gem.description = 'A command-line interface to Travis CI'
+  gem.summary     = gem.description
+  gem.homepage    = 'https://github.com/travis-ci/travis-cli'
 
-  s.files        = Dir['{lib/**/*,spec/**/*,[A-Z]*}']
-  s.executables  = Dir['bin/*'].map { |path| File.basename(path) }
-  s.require_path = 'lib'
-  s.rubyforge_project = '[none]'
+  gem.add_dependency 'thor', '~> 0.16.0'
+  gem.add_dependency 'multi_json', '~> 1.3'
+  gem.add_development_dependency 'rspec', '~> 2.6'
+  gem.add_development_dependency 'webmock', '~> 1.8'
 
-  s.add_dependency 'thor'
-  s.add_dependency 'multi_json'
-  s.add_development_dependency 'rspec', '~> 2.6'
-  s.add_development_dependency 'webmock', '~> 1.8'
+  gem.files         = `git ls-files`.split($/)
+  gem.executables   = gem.files.grep(/^bin/).map{|f| File.basename(f) }
+  gem.test_files    = gem.files.grep(/^spec/)
+  gem.require_paths = ['lib']
 end

--- a/travis-cli.gemspec
+++ b/travis-cli.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'thor'
   s.add_dependency 'multi_json'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'mocha'
+  s.add_development_dependency 'rspec', '~> 2.6'
 end

--- a/travis-cli.gemspec
+++ b/travis-cli.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'thor'
   s.add_dependency 'multi_json'
   s.add_development_dependency 'rspec', '~> 2.6'
+  s.add_development_dependency 'webmock', '~> 1.8'
 end


### PR DESCRIPTION
The Travis API requires a connection over HTTPS but the `SecureKey` class is fetching over HTTP, so it's getting a redirect (301) rather than an OK (200) status. There were no tests surrounding `SecureKey` but there are now and they're green for all of the rubies in `.travis.yml` and a couple more. Although, I wasn't able to check jruby. Hope it helps! Thanks.
