### PR TITLE
Require require 'net/https'

### DIFF
--- a/lib/travis/cli/secure_key.rb
+++ b/lib/travis/cli/secure_key.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'net/http'
+require 'net/https'
 require 'multi_json'
 require 'openssl'
 require 'base64'


### PR DESCRIPTION
When I tried to encrypt a value:

```
travis encrypt tax/python-requests-aws AWS_ACCESS_KEY=XXX
```

I received the following error

```
Library/Ruby/Gems/1.8/gems/travis-0.0.8/lib/travis/cli/secure_key.rb:29:in `fetch_key': undefined method `use_ssl=' for #<Net::HTTP secure.travis-ci.org:443 open=false> (NoMethodError)
    from /Library/Ruby/Gems/1.8/gems/travis-0.0.8/lib/travis/cli/secure_key.rb:22:in `key'
    from /Library/Ruby/Gems/1.8/gems/travis-0.0.8/lib/travis/cli/secure_key.rb:18:in `encrypt'
    from /Library/Ruby/Gems/1.8/gems/travis-0.0.8/lib/travis/cli.rb:39:in `encrypt'
    from /Library/Ruby/Gems/1.8/gems/thor-0.16.0/lib/thor/task.rb:27:in `send'
    from /Library/Ruby/Gems/1.8/gems/thor-0.16.0/lib/thor/task.rb:27:in `run'
    from /Library/Ruby/Gems/1.8/gems/thor-0.16.0/lib/thor/invocation.rb:120:in `invoke_task'
    from /Library/Ruby/Gems/1.8/gems/thor-0.16.0/lib/thor.rb:275:in `dispatch'
    from /Library/Ruby/Gems/1.8/gems/thor-0.16.0/lib/thor/base.rb:425:in `start'
    from /Library/Ruby/Gems/1.8/gems/travis-0.0.8/bin/travis:11
    from /usr/bin/travis:19:in `load'
    from /usr/bin/travis:19
```

**Warning** This is the first line (words actually) of ruby code I ever wrote but it did fix the problem for me
