### PR TITLE
Fixed Printing of Encrypted Config

### DIFF
--- a/lib/travis/cli.rb
+++ b/lib/travis/cli.rb
@@ -45,7 +45,7 @@ module Travis
 
       puts "Please add the following to your .travis.yml file:"
       puts ""
-      puts "  secure: \"#{Base64.encode64(encrypted).strip.gsub("\n", "\\n")}\""
+      puts "    - secure: \"#{Base64.encode64(encrypted).strip.gsub("\n", "\\n")}\""
       puts ""
     end
   end


### PR DESCRIPTION
In the .travis.yml file, secure config variables have 4 spaces and a hyphen in front of secure.
Example from [Travis docs](http://about.travis-ci.org/blog/2012-12-18-travis-artifacts/):

```
   - secure: ".......long encrypted string............."
```
