### PR TITLE
Add ability to load includes in yaml config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 script: rspec
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - jruby

--- a/lib/travis/deploy.rb
+++ b/lib/travis/deploy.rb
@@ -17,9 +17,12 @@ module Travis
     method_option :env,    :aliases => '-e', :type => :string
     method_option :source, :aliases => '-s', :type => :string
     method_option :backup, :aliases => '-b', :type => :boolean, :default => false
+    method_option :pretend, :type => :boolean, :default => false
+    method_option :app, :type => :string
 
     def config(remote)
-      Config.new(shell, remote, options).invoke
+      config = Config.new(shell, remote, options)
+      options[:pretend] ? config.pretend : config.invoke
     end
 
     desc 'deploy', 'Deploy to the given remote'

--- a/lib/travis/deploy/config/builder.rb
+++ b/lib/travis/deploy/config/builder.rb
@@ -1,0 +1,33 @@
+class Travis::Deploy::Config
+  class Builder
+    attr_reader :config, :env, :keychain
+
+    def initialize(keychain, env)
+      @keychain = keychain
+      @config = YAML.load(keychain.source)
+      @env = env
+    end
+
+    def build
+      includes = []
+
+      includes << config.delete('includes') if config['includes']
+      includes << env_config.delete('includes') if env_config['includes']
+
+      includes.flatten!
+
+      result = env_config
+      includes.each do |name|
+        include_config = keychain.includes(name)
+        result.merge! include_config['all'] || {}
+        result.merge! include_config[env] || {}
+      end
+
+      result
+    end
+
+    def env_config
+      config.fetch env, {}
+    end
+  end
+end

--- a/lib/travis/keychain.rb
+++ b/lib/travis/keychain.rb
@@ -15,7 +15,30 @@ module Travis
       read
     end
 
+    def source
+      @source ||= fetch
+    end
+
+    def includes(name)
+      include_files[name]
+    end
+
     protected
+
+      def include_files
+        @include_files ||= begin
+          contents = {}
+
+          chdir do
+            Dir['config/includes/*.yml'].each do |path|
+              name = File.basename(path).sub(/\.yml$/, '')
+              contents[name] = YAML.load(File.read(path))
+            end
+          end
+
+          contents
+        end
+      end
 
       def pull
         error 'There are unstaged changes in your travis-keychain working directory.' unless clean?

--- a/spec/travis/deploy/config/builder_spec.rb
+++ b/spec/travis/deploy/config/builder_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+class Travis::Deploy::Config
+  describe Builder do
+    let(:env) { 'staging' }
+    let(:config) { "staging:\n  foo: bar" }
+    let(:keychain) { stub(:keychain, source: @config || config) }
+    let(:builder) { Builder.new(keychain, env) }
+
+    it 'loads config for given env' do
+      builder.build.should == { 'foo' => 'bar' }
+    end
+
+    it 'includes files specified at a top level' do
+      @config = YAML.dump 'includes' => ['pusher'], 'staging' => { 'foo' => 'bar' }
+      pusher_config = {
+        'all' => { 'bar' => 'baz', 'baz' => 'should be overwritten' },
+        'staging' => { 'baz' => 'qux' },
+        'development' => { 'no' => 'no' }
+      }
+      keychain.should_receive(:includes).with('pusher').and_return(pusher_config)
+
+      builder.build.should == { 'foo' => 'bar', 'bar' => 'baz', 'baz' => 'qux' }
+    end
+
+    it 'includes files specified for an env' do
+      @config = YAML.dump 'staging' => { 'foo' => 'bar', 'includes' => ['pusher'] },
+                          'production' => { 'includes' => ['encryption'] }
+
+      pusher_config = {
+        'all' => { 'bar' => 'baz', 'baz' => 'should be overwritten' },
+        'staging' => { 'baz' => 'qux' },
+        'development' => { 'no' => 'no' }
+      }
+      keychain.should_receive(:includes).with('pusher').and_return(pusher_config)
+
+      builder.build.should == { 'foo' => 'bar', 'bar' => 'baz', 'baz' => 'qux' }
+
+    end
+  end
+end

--- a/spec/travis/deploy/config_spec.rb
+++ b/spec/travis/deploy/config_spec.rb
@@ -7,14 +7,14 @@ describe Travis::Deploy::Config do
   before :each do
     Travis::Deploy::Config.any_instance.stub(:clean? => true)
     Travis::Deploy::Config.any_instance.stub(:run)
-    Travis::Keychain.any_instance.stub(:fetch => config)
+    Travis::Keychain.any_instance.stub(:source => config)
     File.stub(:open)
   end
 
   describe 'sync' do
     it 'fetches the config from the keychain' do
       command = Travis::Deploy::Config.new(shell, 'staging', {})
-      command.send(:keychain).should_receive(:fetch).and_return(config)
+      command.send(:keychain).should_receive(:source).and_return(config)
       command.invoke
     end
 


### PR DESCRIPTION
From commit message:

```
We often need to reuse configuration between apps, extracting those
reusable configs to a separate files will simplify making changes, such
as changing credentials.

This commit adds ability to include files into configs. Includes can be
both global and local for given env:

    includes: # will be included in all envs
      - pusher

    production:
      includes: # will be included for production only
        - encryption

Included files can contain configuration for each env separately, but
also specify config for all environments. For example sponsors.yml could
look like this:

    all: # will be included regardless of env
      sponsors:
        - sponsor 1
        - sponsor 2

And database.yml could look like this:

    production:
      host: some-host

    staging:
      host: other-host
```
